### PR TITLE
feat: useResponsive hook 구현 및 테스트 코드 작성

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useResponsive'

--- a/src/hooks/useResponsive.test.ts
+++ b/src/hooks/useResponsive.test.ts
@@ -59,4 +59,32 @@ describe('hooks/useResponsive()', () => {
     // Then
     expect(result.current).toBe('outlineDisabled')
   })
+
+  it('viewport가 tablet 미디어쿼리 값에 해당하지만 tablet이 없는 경우, ButtonProps의 styleType 값을 desktop 값인 ghost로 리턴해야 합니다.', () => {
+    // Given, When
+    setViewPort('tablet')
+    const { result } = renderHook(() => {
+      return useResponsive<ButtonProps, 'styleType'>({
+        desktop: 'ghost',
+        mobile: 'outline'
+      })
+    })
+
+    // Then
+    expect(result.current).toBe('ghost')
+  })
+
+  it('viewport가 mobile 미디어쿼리 값에 해당하지만 mobile이 없는 경우, ButtonProps의 styleType 값을 tablet 값인 ghost로 리턴해야 합니다.', () => {
+    // Given, When
+    setViewPort('mobile')
+    const { result } = renderHook(() => {
+      return useResponsive<ButtonProps, 'styleType'>({
+        desktop: 'ghost',
+        tablet: 'outlineDisabled'
+      })
+    })
+
+    // Then
+    expect(result.current).toBe('outlineDisabled')
+  })
 })

--- a/src/hooks/useResponsive.test.ts
+++ b/src/hooks/useResponsive.test.ts
@@ -1,0 +1,62 @@
+import type { AvatarProps, ButtonProps } from '@offer-ui/react'
+import { renderHook } from '@testing-library/react'
+import { vi } from 'vitest'
+import { useResponsive } from './useResponsive'
+import { matchMediaQuery } from '@styles'
+
+describe('hooks/useResponsive()', () => {
+  const setViewPort = (device: keyof typeof matchMediaQuery): void => {
+    window.matchMedia = vi.fn().mockImplementation(query => ({
+      addEventListener: vi.fn(),
+      matches: query === matchMediaQuery[device],
+      media: '',
+      onchange: null,
+      removeEventListener: vi.fn()
+    }))
+  }
+
+  it('viewport가 desktop 미디어쿼리 값에 해당하는 경우, AvatarProps의 size 값을 medium으로 리턴해야 합니다.', () => {
+    // Given, When
+    setViewPort('desktop')
+    const { result } = renderHook(() => {
+      return useResponsive<AvatarProps, 'size'>({
+        desktop: 'medium',
+        mobile: 'small',
+        tablet: 'small'
+      })
+    })
+
+    // Then
+    expect(result.current).toBe('medium')
+  })
+
+  it('viewport가 mobile 미디어쿼리 값에 해당하는 경우, AvatarProps의 size 값을 small로 리턴해야 합니다.', () => {
+    // Given, When
+    setViewPort('mobile')
+    const { result } = renderHook(() => {
+      return useResponsive<AvatarProps, 'size'>({
+        desktop: 'medium',
+        mobile: 'small',
+        tablet: 'xsmall'
+      })
+    })
+
+    // Then
+    expect(result.current).toBe('small')
+  })
+
+  it('viewport가 tablet 미디어쿼리 값에 해당하는 경우, ButtonProps의 styleType 값을 outlineDisabled로 리턴해야 합니다.', () => {
+    // Given, When
+    setViewPort('tablet')
+    const { result } = renderHook(() => {
+      return useResponsive<ButtonProps, 'styleType'>({
+        desktop: 'ghost',
+        mobile: 'outline',
+        tablet: 'outlineDisabled'
+      })
+    })
+
+    // Then
+    expect(result.current).toBe('outlineDisabled')
+  })
+})

--- a/src/hooks/useResponsive.ts
+++ b/src/hooks/useResponsive.ts
@@ -1,14 +1,11 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+import type { Device, MatchMediaQuery } from '@styles'
 import { matchMediaQuery as defaultMatchMediaQuery } from '@styles'
 
-type Device = 'desktop' | 'tablet' | 'mobile'
-type MaxWidth = number
-
-type ResponsiveCase<T, K extends keyof T> = {
-  [key in Device]: T[K]
-}
-type MatchMediaQuery = {
-  [key in Device]: `(max-width: ${MaxWidth}px)`
+interface ResponsiveCase<T, K extends keyof T> {
+  desktop: T[K]
+  mobile?: T[K]
+  tablet?: T[K]
 }
 type MatchMediaQueryParams = MatchMediaQuery | undefined
 
@@ -18,37 +15,47 @@ type MatchMediaQueryParams = MatchMediaQuery | undefined
  * const avatarSize = useResponsive<AvatarProps, 'size'>({
  *   desktop: 'medium',
  *   tablet: 'small',
- *   mobile: 'small'
+ *   mobile: 'xsmall'
  * });
  */
 export const useResponsive = <T, K extends keyof T>(
   responsiveCase: ResponsiveCase<T, K>,
-  matchMediaQuery: MatchMediaQueryParams = defaultMatchMediaQuery as MatchMediaQuery
+  matchMediaQuery: MatchMediaQueryParams = defaultMatchMediaQuery
 ): T[K] => {
-  const getDevice = (queries: MatchMediaQuery): Device => {
-    const defaultDevice: Device = 'desktop'
+  const getDevice = useCallback(
+    (queries: MatchMediaQuery): Device => {
+      const defaultDevice: Device = 'desktop'
 
-    if (typeof window === 'undefined') {
-      return defaultDevice
-    }
+      if (typeof window === 'undefined') {
+        return defaultDevice
+      }
 
-    return Object.keys(queries).reduce<Device>((prev, cur) => {
-      const device = cur as Device
-      const query = queries[device] as string
+      const device = (Object.keys(queries) as Device[]).reduce(
+        (prev, device) => {
+          const query = queries[device]
 
-      return window.matchMedia(query).matches ? device : prev
-    }, defaultDevice)
-  }
+          return window.matchMedia(query).matches ? device : prev
+        },
+        defaultDevice
+      )
+      const isTablet = device === 'tablet'
+
+      return responsiveCase[device] ? device : isTablet ? 'desktop' : 'tablet'
+    },
+    [responsiveCase]
+  )
 
   const [currentDevice, setCurrentDevice] = useState<Device>(
     getDevice(matchMediaQuery)
   )
 
   useEffect(() => {
-    const matchMedia = Object.keys(matchMediaQuery).map(device => {
-      const query = matchMediaQuery[device as Device] as string
-      return window.matchMedia(query)
-    })
+    const matchMedia = (Object.keys(matchMediaQuery) as Device[]).map(
+      device => {
+        const query = matchMediaQuery[device]
+        return window.matchMedia(query)
+      }
+    )
 
     const handleChange = (): void => {
       setCurrentDevice(getDevice(matchMediaQuery))
@@ -65,7 +72,7 @@ export const useResponsive = <T, K extends keyof T>(
         media.removeEventListener('change', handleChange)
       })
     }
-  }, [matchMediaQuery])
+  }, [matchMediaQuery, getDevice])
 
   return responsiveCase[currentDevice] as T[K]
 }

--- a/src/hooks/useResponsive.ts
+++ b/src/hooks/useResponsive.ts
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react'
+import { matchMediaQuery as defaultMatchMediaQuery } from '@styles'
+
+type Device = 'desktop' | 'tablet' | 'mobile'
+type MaxWidth = number
+
+type ResponsiveCase<T, K extends keyof T> = {
+  [key in Device]: T[K]
+}
+type MatchMediaQuery = {
+  [key in Device]: `(max-width: ${MaxWidth}px)`
+}
+type MatchMediaQueryParams = MatchMediaQuery | undefined
+
+/**
+ *
+ * @example
+ * const avatarSize = useResponsive<AvatarProps, 'size'>({
+ *   desktop: 'medium',
+ *   tablet: 'small',
+ *   mobile: 'small'
+ * });
+ */
+export const useResponsive = <T, K extends keyof T>(
+  responsiveCase: ResponsiveCase<T, K>,
+  matchMediaQuery: MatchMediaQueryParams = defaultMatchMediaQuery as MatchMediaQuery
+): T[K] => {
+  const getDevice = (queries: MatchMediaQuery): Device => {
+    const defaultDevice: Device = 'desktop'
+
+    if (typeof window === 'undefined') {
+      return defaultDevice
+    }
+
+    return Object.keys(queries).reduce<Device>((prev, cur) => {
+      const device = cur as Device
+      const query = queries[device] as string
+
+      return window.matchMedia(query).matches ? device : prev
+    }, defaultDevice)
+  }
+
+  const [currentDevice, setCurrentDevice] = useState<Device>(
+    getDevice(matchMediaQuery)
+  )
+
+  useEffect(() => {
+    const matchMedia = Object.keys(matchMediaQuery).map(device => {
+      const query = matchMediaQuery[device as Device] as string
+      return window.matchMedia(query)
+    })
+
+    const handleChange = (): void => {
+      setCurrentDevice(getDevice(matchMediaQuery))
+    }
+
+    handleChange()
+
+    matchMedia.forEach(media => {
+      media.addEventListener('change', handleChange)
+    })
+
+    return () => {
+      matchMedia.forEach(media => {
+        media.removeEventListener('change', handleChange)
+      })
+    }
+  }, [matchMediaQuery])
+
+  return responsiveCase[currentDevice] as T[K]
+}

--- a/src/styles/themes/mediaQuery.ts
+++ b/src/styles/themes/mediaQuery.ts
@@ -10,3 +10,9 @@ export const mediaQuery = {
   mobile: '@media (max-width: 699px)',
   tablet: '@media (max-width: 1023px)'
 } as const
+
+export const matchMediaQuery = {
+  desktop: '(max-width: 1920px)',
+  mobile: '(max-width: 699px)',
+  tablet: '(max-width: 1023px)'
+}

--- a/src/styles/themes/mediaQuery.ts
+++ b/src/styles/themes/mediaQuery.ts
@@ -11,7 +11,13 @@ export const mediaQuery = {
   tablet: '@media (max-width: 1023px)'
 } as const
 
-export const matchMediaQuery = {
+type MaxWidth = number
+export type Device = keyof typeof mediaQuery
+
+export type MatchMediaQuery = {
+  [key in Device]: `(max-width: ${MaxWidth}px)`
+}
+export const matchMediaQuery: MatchMediaQuery = {
   desktop: '(max-width: 1920px)',
   mobile: '(max-width: 699px)',
   tablet: '(max-width: 1023px)'


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #49 

## ⛳ 구현 사항
- 미디어쿼리에 해당하는 props의 값을 반환하는 useResponsive 훅을 구현하였습니다.

## 📚 구현 설명
**_import_**
```tsx
...
import { useResponsive } from '@hooks'
import type { AvatarProps } from '@offer-ui/react'
```
**_usage_**
```tsx
...
const avatarSize = useResponsive<AvatarProps, 'size'>({
  desktop: 'medium',
  tablet: 'small',
  mobile: 'small'
})

return (
  <Avatar size={avatarSize}  alt="avatar" src={src} />
)
```
- `useResponsive`의 제네릭 첫번째 인자 : `컴포넌트의 props`
- `useResponsive`의 제네릭 두번째 인자 : `미디어 쿼리에 따른 변환이 필요한 prop`

 <!-- ## ⏳ 실행 화면 -->

<!-- ## 💡 코드 리뷰 포인트 -->

<!-- ## 🔥 이슈와 해결 방안 -->

<!-- ## 🛠 피드백 반영 사항 -->
