### PR TITLE
fix: storybook 에러 디버깅

### DIFF
--- a/.storybook/config/nextImage.js
+++ b/.storybook/config/nextImage.js
@@ -1,0 +1,9 @@
+import * as NextImage from 'next/image'
+
+const OriginalNextImage = NextImage.default
+Object.defineProperty(NextImage, 'default', {
+  configurable: true,
+  value: props => <OriginalNextImage {...props} unoptimized />
+})
+
+export default OriginalNextImage

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -18,6 +18,8 @@ module.exports = {
         extensions: config.resolve.extensions
       })
     ]
+    config.resolve.alias["next/image"] = require.resolve("./config/nextImage.js");
+
     return config
   }
 }

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,7 +1,6 @@
 import { theme } from '@themes'
 import { ThemeProvider } from '@emotion/react'
 import { GlobalStyle } from '../src/styles'
-import * as NextImage from 'next/image'
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
@@ -22,8 +21,5 @@ export const decorators = [
   )
 ]
 
-const OriginalNextImage = NextImage.default
-Object.defineProperty(NextImage, 'default', {
-  configurable: true,
-  value: props => <OriginalNextImage {...props} unoptimized />
-})
+
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,8 @@
     "source.fixAll.eslint": true,
     "source.fixAll.stylelint": true
   },
-  "cSpell.words": ["stylelint"]
+  "cSpell.words": [
+    "stylelint",
+    "unoptimized"
+  ]
 }


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #109 

## ⛳ 구현 사항

- storybook server, build 이슈를 해결 하였습니다.
  - 원인 : Storybook 6.5버전에서 `defineProperty`가 동작하지 않는 이슈
  - 해결 방안 : storybook에서 build, server를 띄울 때 사용되는 webpack의 next/image alias에 nextImageConfig를 등록

### References

- https://github.com/storybookjs/storybook/issues/17950


## ⏳ 실행 화면

### AS-IS

<img width="455" alt="image" src="https://github.com/price-offer/offer-fe/assets/47546413/bcf1f3b4-6bbf-461a-8376-5610e942b106">

### TO-BE
<img width="994" alt="image" src="https://github.com/price-offer/offer-fe/assets/47546413/f6de7f39-9910-424c-93cd-bba3609de503">



<!-- ## 💡 코드 리뷰 포인트 -->

<!-- ## 🔥 이슈와 해결 방안 -->

<!-- ## 🛠 피드백 반영 사항 -->
