### PR TITLE
feat: @suspensive/react 도입 및 suspense + useSuspenseQuery 형태로 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@emotion/react": "^11.10.0",
     "@emotion/styled": "^11.10.0",
     "@offer-ui/react": "^0.2.1",
+    "@suspensive/react": "^1.20.7",
     "@tanstack/react-query": "^5.8.3",
     "axios": "^1.2.3",
     "cookies-next": "^4.1.0",

--- a/src/apis/auth/queries.ts
+++ b/src/apis/auth/queries.ts
@@ -5,6 +5,5 @@ export const useLoginQuery = (kakaoCode: string) =>
   useQuery({
     queryKey: ['login'],
     queryFn: () => getLogin({ code: kakaoCode }),
-    enabled: Boolean(kakaoCode),
-    select: res => res.data
+    enabled: Boolean(kakaoCode)
   })

--- a/src/apis/member/queries.ts
+++ b/src/apis/member/queries.ts
@@ -1,10 +1,9 @@
-import { useQuery } from '@tanstack/react-query'
+import { useSuspenseQuery } from '@tanstack/react-query'
 import { getMyProfile } from './apis'
 
 export const useGetMyProfileQuery = (accessToken?: string) =>
-  useQuery({
+  useSuspenseQuery({
     queryKey: ['myProfile', accessToken],
     queryFn: getMyProfile,
-    enabled: Boolean(accessToken),
     select: res => res.data
   })

--- a/src/apis/member/queries.ts
+++ b/src/apis/member/queries.ts
@@ -4,6 +4,5 @@ import { getMyProfile } from './apis'
 export const useGetMyProfileQuery = (accessToken?: string) =>
   useSuspenseQuery({
     queryKey: ['myProfile', accessToken],
-    queryFn: getMyProfile,
-    select: res => res.data
+    queryFn: getMyProfile
   })

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -6,6 +6,7 @@ import type { ReactElement } from 'react'
 import { useState } from 'react'
 import { SearchArea } from './SearchArea'
 import { SideBar } from './SideBar'
+import { HeaderSkeleton } from './skeleton'
 import { Styled } from './styled'
 import { CommonModal } from '../CommonModal'
 import { Dialog } from '../Dialog'
@@ -173,4 +174,4 @@ const Header = (): ReactElement => {
   )
 }
 
-export { Header }
+export { Header, HeaderSkeleton }

--- a/src/components/common/Header/skeleton.tsx
+++ b/src/components/common/Header/skeleton.tsx
@@ -1,0 +1,63 @@
+import styled from '@emotion/styled'
+import { Avatar, Button, Divider, IconButton } from '@offer-ui/react'
+import Image from 'next/image'
+import Link from 'next/link'
+import type { ReactElement } from 'react'
+import { Styled } from './styled'
+import { noop } from '@utils/common'
+import { IMAGE } from '@constants'
+
+export const HeaderSkeleton = (): ReactElement => {
+  return (
+    <Styled.HeaderWrapper>
+      <Styled.HeaderContent>
+        <Styled.LogoInputSection>
+          <Link href="/">
+            <Styled.LogoButton styleType="ghost">
+              <Image alt="Logo" height={40} src={IMAGE.LOGO} width={72} />
+            </Styled.LogoButton>
+          </Link>
+          <Styled.InputWrapper>
+            <Styled.SearchInput
+              placeholder="검색어를 입력하세요"
+              styleType="search"
+            />
+          </Styled.InputWrapper>
+        </Styled.LogoInputSection>
+        <Styled.ButtonSection>
+          <>
+            <Styled.HeaderAuthButton
+              styleType="ghost"
+              type="button"
+              width="76px">
+              <Styled.TextLink href="/mypage">나의 거래활동</Styled.TextLink>
+            </Styled.HeaderAuthButton>
+            <Divider direction="vertical" gap={16} />
+            <Styled.HeaderAuthButton styleType="ghost" width="37px">
+              <Styled.TextLink href="/messagebox">쪽지함</Styled.TextLink>
+            </Styled.HeaderAuthButton>
+            <Styled.HeaderProfileSection onClick={noop}>
+              <Avatar alt="profile-image" size="xsmall" src="" />
+              <StyledSkeletonHeaderNickName />
+              <IconButton icon="triangleDown" />
+            </Styled.HeaderProfileSection>
+          </>
+          <Link href="/post">
+            <Button size="small" styleType="solidSub">
+              판매하기
+            </Button>
+          </Link>
+        </Styled.ButtonSection>
+        <Styled.MenuSection>
+          <IconButton icon="search" size={24} />
+          <IconButton icon="menu" size={24} />
+        </Styled.MenuSection>
+      </Styled.HeaderContent>
+    </Styled.HeaderWrapper>
+  )
+}
+
+// TODO: Header Layout shift 수정 필요
+const StyledSkeletonHeaderNickName = styled(Styled.HeaderNickName)`
+  min-width: 100px;
+`

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -3,18 +3,6 @@ import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import { useGetMyProfileQuery } from '@apis/member'
 
-const EMPTY_COUNT_NUMBER = -1
-const initialUser = {
-  id: EMPTY_COUNT_NUMBER,
-  nickname: '',
-  profileImageUrl: '',
-  likeProductCount: EMPTY_COUNT_NUMBER,
-  offerLevel: EMPTY_COUNT_NUMBER,
-  reviewCount: EMPTY_COUNT_NUMBER,
-  sellingProductCount: EMPTY_COUNT_NUMBER,
-  soldProductCount: EMPTY_COUNT_NUMBER
-}
-
 export const useAuth = () => {
   const router = useRouter()
   const accessToken = getCookie('accessToken')
@@ -35,6 +23,6 @@ export const useAuth = () => {
   return {
     isLogin,
     handleLogout,
-    user: userData || initialUser
+    user: userData
   }
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,7 +3,7 @@ import { ErrorBoundary, Suspense } from '@suspensive/react'
 import {
   QueryClient,
   QueryClientProvider,
-  useQueryErrorResetBoundary
+  QueryErrorResetBoundary
 } from '@tanstack/react-query'
 import type { AppProps } from 'next/app'
 import type { ReactElement } from 'react'
@@ -26,20 +26,22 @@ if (isUseMock) {
 const queryClient = new QueryClient()
 
 const App = ({ Component, pageProps }: AppProps): ReactElement | null => {
-  const { reset } = useQueryErrorResetBoundary()
-
   return (
     <QueryClientProvider client={queryClient}>
-      <ErrorBoundary fallback={<div>Error</div>} onReset={reset}>
-        <OfferStyleProvider theme={customTheme}>
-          <Suspense.CSROnly fallback={<HeaderSkeleton />}>
-            <Header />
-          </Suspense.CSROnly>
-          <Layout>
-            <Component {...pageProps} />
-          </Layout>
-        </OfferStyleProvider>
-      </ErrorBoundary>
+      <QueryErrorResetBoundary>
+        {({ reset }) => (
+          <ErrorBoundary fallback={<div>Error</div>} onReset={reset}>
+            <OfferStyleProvider theme={customTheme}>
+              <Suspense.CSROnly fallback={<HeaderSkeleton />}>
+                <Header />
+              </Suspense.CSROnly>
+              <Layout>
+                <Component {...pageProps} />
+              </Layout>
+            </OfferStyleProvider>
+          </ErrorBoundary>
+        )}
+      </QueryErrorResetBoundary>
     </QueryClientProvider>
   )
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,8 +1,13 @@
 import { OfferStyleProvider, theme as offerTheme } from '@offer-ui/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ErrorBoundary, Suspense } from '@suspensive/react'
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQueryErrorResetBoundary
+} from '@tanstack/react-query'
 import type { AppProps } from 'next/app'
 import type { ReactElement } from 'react'
-import { Header } from '@components/common/Header'
+import { Header, HeaderSkeleton } from '@components/common/Header'
 import { env } from '@constants'
 import { Layout } from '@layouts'
 import { theme } from '@styles'
@@ -21,14 +26,20 @@ if (isUseMock) {
 const queryClient = new QueryClient()
 
 const App = ({ Component, pageProps }: AppProps): ReactElement | null => {
+  const { reset } = useQueryErrorResetBoundary()
+
   return (
     <QueryClientProvider client={queryClient}>
-      <OfferStyleProvider theme={customTheme}>
-        <Header />
-        <Layout>
-          <Component {...pageProps} />
-        </Layout>
-      </OfferStyleProvider>
+      <ErrorBoundary fallback={<div>Error</div>} onReset={reset}>
+        <OfferStyleProvider theme={customTheme}>
+          <Suspense.CSROnly fallback={<HeaderSkeleton />}>
+            <Header />
+          </Suspense.CSROnly>
+          <Layout>
+            <Component {...pageProps} />
+          </Layout>
+        </OfferStyleProvider>
+      </ErrorBoundary>
     </QueryClientProvider>
   )
 }

--- a/src/utils/http/index.ts
+++ b/src/utils/http/index.ts
@@ -33,34 +33,31 @@ export type CommonResponse<T> = {
   message: string
 }
 
-const getResult = <T>(response: AxiosResponse<T>): T => response.data
+const getResult = <T>(response: AxiosResponse<CommonResponse<T>>): T =>
+  response.data.data
 
 export const http = {
   get: <Request = unknown, Response = unknown>(
     url: string,
     params?: Request
-  ): Promise<CommonResponse<Response>> =>
-    Axios.get<
-      CommonResponse<Response>,
-      AxiosResponse<CommonResponse<Response>>,
-      Request
-    >(url, { params }).then(getResult),
+  ): Promise<Response> =>
+    Axios.get<Response, AxiosResponse<CommonResponse<Response>>, Request>(url, {
+      params
+    }).then(getResult),
   post: <Request = unknown, Response = unknown>(
     url: string,
     payload?: Request
-  ): Promise<CommonResponse<Response>> =>
+  ): Promise<Response> =>
     Axios.post<CommonResponse<Response>>(url, payload).then(getResult),
   put: <Request = unknown, Response = unknown>(
     url: string,
     payload?: Request
-  ): Promise<CommonResponse<Response>> =>
+  ): Promise<Response> =>
     Axios.put<CommonResponse<Response>>(url, payload).then(getResult),
   patch: <Request = unknown, Response = unknown>(
     url: string,
     payload?: Request
-  ) => Axios.patch<Response>(url, payload).then(getResult),
-  delete: <Response = unknown>(
-    url: string
-  ): Promise<CommonResponse<Response>> =>
+  ) => Axios.patch<CommonResponse<Response>>(url, payload).then(getResult),
+  delete: <Response = unknown>(url: string): Promise<Response> =>
     Axios.delete<CommonResponse<Response>>(url).then(getResult)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3062,6 +3062,11 @@
   dependencies:
     "@babel/core" "^7.17.9"
 
+"@suspensive/react@^1.20.7":
+  version "1.20.7"
+  resolved "https://registry.yarnpkg.com/@suspensive/react/-/react-1.20.7.tgz#58fdab664ab54388688a42296f2f09ad5942f535"
+  integrity sha512-64KNgOloluurl0Hc/UCZg+VYnJkh4CA6ovw0ncPCL+ufpIk6L71WsUkfUvLN4PRPIY9hyT7TCU1Qpm6BUqY0Lw==
+
 "@swc/core-darwin-arm64@1.3.96":
   version "1.3.96"
   resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.96.tgz#7c1c4245ce3f160a5b36a48ed071e3061a839e1d"


### PR DESCRIPTION
## ⛳ 구현 사항
- suspense + react query 사용 시, dx와 ux 향상을 위해 suspensive 패키지를 설치하였습니다.
- 각 컴포넌트의 스켈레톤이 따로 구현되어 있지 않아 임의로 스켈레톤을 설정하였습니다.
  (TODO에 적어둔 layoutshift 발생하는 부분은 추후 수정이 필요할 것 같습니다.)
- ErrorBoundary를 설정하였습니다.
- axios response를 data만 제공하도록 변경하였습니다.

## 📚 구현 설명
- useQuery -> useSuspenseQuery로 변경
  - enabled를 제공하지 않습니다.
  - useSuspenseQuery를 사용하고 있는 컴포넌트 외부를 `Suspense.CSRonly`로 감싸주어야 합니다.
    (suspense가 client환경에서만 동작하기 위해)
- fallback ui로 skeleton 컴포넌트를 구현하였습니다.

## ⏳ 실행 화면
https://github.com/price-offer/offer-fe/assets/47546413/4d4326da-0bff-4623-89a4-89e4769c32eb



## 🔥 이슈와 해결 방안
- 사이트 리로드 시, css가 잠깐 깨지는 현상 (디버깅 필요)
- Suspense fallback UI가 보여질 때, layout shift 현상 해결 필요
