### PR TITLE
feat: post 페이지에서 header 로고만 보이게

### DIFF
--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -14,8 +14,11 @@ import { useAuth } from '@hooks/useAuth'
 import useModal from '@hooks/useModal'
 import { IMAGE } from '@constants'
 
+const PREVENT_ACTIVE_PATHS = ['/post']
+
 const Header = (): ReactElement => {
   const router = useRouter()
+  const isActivePath = !PREVENT_ACTIVE_PATHS.includes(router.pathname)
   const { isLogin, user, handleLogout } = useAuth()
   const { isOpen, openModal, closeModal } = useModal()
   const [isOpenSideBar, setIsOpenSideBar] = useState(false)
@@ -42,82 +45,88 @@ const Header = (): ReactElement => {
                 <Image alt="Logo" height={40} src={IMAGE.LOGO} width={72} />
               </Styled.LogoButton>
             </Link>
-            <Styled.InputWrapper>
-              <Styled.SearchInput
-                placeholder="검색어를 입력하세요"
-                styleType="search"
-              />
-            </Styled.InputWrapper>
-          </Styled.LogoInputSection>
-          <Styled.ButtonSection>
-            {isLogin ? (
-              <>
-                <Styled.HeaderAuthButton
-                  styleType="ghost"
-                  type="button"
-                  width="76px">
-                  <Styled.TextLink href="/mypage">
-                    나의 거래활동
-                  </Styled.TextLink>
-                </Styled.HeaderAuthButton>
-                <Divider direction="vertical" gap={16} />
-                <Styled.HeaderAuthButton styleType="ghost" width="37px">
-                  <Styled.TextLink href="/messagebox">쪽지함</Styled.TextLink>
-                </Styled.HeaderAuthButton>
-                <Styled.HeaderProfileSection
-                  onClick={() =>
-                    setIsOpenDialog({
-                      ...isOpenDialog,
-                      logout: !isOpenDialog.logout
-                    })
-                  }>
-                  <Avatar
-                    alt="profile-image"
-                    size="xsmall"
-                    src={user.profileImageUrl}
-                  />
-                  <Styled.HeaderNickName>{user.nickname}</Styled.HeaderNickName>
-                  <IconButton icon="triangleDown" />
-                  {isOpenDialog.logout && (
-                    <Dialog
-                      dialogPositionStyle={{
-                        top: '35px',
-                        left: '15px'
-                      }}
-                      onClose={() =>
-                        setIsOpenDialog({
-                          ...isOpenDialog,
-                          logout: false
-                        })
-                      }>
-                      <Styled.LogoutButton onClick={handleLogout}>
-                        로그아웃
-                      </Styled.LogoutButton>
-                    </Dialog>
-                  )}
-                </Styled.HeaderProfileSection>
-              </>
-            ) : (
-              <>
-                <Styled.HeaderAuthButton
-                  styleType="ghost"
-                  width="37px"
-                  onClick={handleOpenLoginModal}>
-                  로그인
-                </Styled.HeaderAuthButton>
-                <Divider direction="vertical" gap={16} />
-                <Styled.HeaderAuthButton styleType="ghost" width="50px">
-                  회원가입
-                </Styled.HeaderAuthButton>
-                <Styled.SellButtonDivider />
-              </>
+            {isActivePath && (
+              <Styled.InputWrapper>
+                <Styled.SearchInput
+                  placeholder="검색어를 입력하세요"
+                  styleType="search"
+                />
+              </Styled.InputWrapper>
             )}
-            <Link href="/post">
-              <Button size="small" styleType="solidSub">
-                판매하기
-              </Button>
-            </Link>
-          </Styled.ButtonSection>
+          </Styled.LogoInputSection>
+          {isActivePath && (
+            <Styled.ButtonSection>
+              {isLogin ? (
+                <>
+                  <Styled.HeaderAuthButton
+                    styleType="ghost"
+                    type="button"
+                    width="76px">
+                    <Styled.TextLink href="/mypage">
+                      나의 거래활동
+                    </Styled.TextLink>
+                  </Styled.HeaderAuthButton>
+                  <Divider direction="vertical" gap={16} />
+                  <Styled.HeaderAuthButton styleType="ghost" width="37px">
+                    <Styled.TextLink href="/messagebox">쪽지함</Styled.TextLink>
+                  </Styled.HeaderAuthButton>
+                  <Styled.HeaderProfileSection
+                    onClick={() =>
+                      setIsOpenDialog({
+                        ...isOpenDialog,
+                        logout: !isOpenDialog.logout
+                      })
+                    }>
+                    <Avatar
+                      alt="profile-image"
+                      size="xsmall"
+                      src={user.profileImageUrl}
+                    />
+                    <Styled.HeaderNickName>
+                      {user.nickname}
+                    </Styled.HeaderNickName>
+                    <IconButton icon="triangleDown" />
+                    {isOpenDialog.logout && (
+                      <Dialog
+                        dialogPositionStyle={{
+                          top: '35px',
+                          left: '15px'
+                        }}
+                        onClose={() =>
+                          setIsOpenDialog({
+                            ...isOpenDialog,
+                            logout: false
+                          })
+                        }>
+                        <Styled.LogoutButton onClick={handleLogout}>
+                          로그아웃
+                        </Styled.LogoutButton>
+                      </Dialog>
+                    )}
+                  </Styled.HeaderProfileSection>
+                </>
+              ) : (
+                <>
+                  <Styled.HeaderAuthButton
+                    styleType="ghost"
+                    width="37px"
+                    onClick={handleOpenLoginModal}>
+                    로그인
+                  </Styled.HeaderAuthButton>
+                  <Divider direction="vertical" gap={16} />
+                  <Styled.HeaderAuthButton styleType="ghost" width="50px">
+                    회원가입
+                  </Styled.HeaderAuthButton>
+                  <Styled.SellButtonDivider />
+                </>
+              )}
+              <Link href="/post">
+                <Button size="small" styleType="solidSub">
+                  판매하기
+                </Button>
+              </Link>
+            </Styled.ButtonSection>
+          )}
           <Styled.MenuSection>
             <IconButton
               icon="search"

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -104,6 +104,11 @@ const Header = (): ReactElement => {
                       </Dialog>
                     )}
                   </Styled.HeaderProfileSection>
+                  <Link href="/post">
+                    <Button size="small" styleType="solidSub">
+                      판매하기
+                    </Button>
+                  </Link>
                 </>
               ) : (
                 <>
@@ -117,14 +122,8 @@ const Header = (): ReactElement => {
                   <Styled.HeaderAuthButton styleType="ghost" width="50px">
                     회원가입
                   </Styled.HeaderAuthButton>
-                  <Styled.SellButtonDivider />
                 </>
               )}
-              <Link href="/post">
-                <Button size="small" styleType="solidSub">
-                  판매하기
-                </Button>
-              </Link>
             </Styled.ButtonSection>
           )}
           <Styled.MenuSection>

--- a/src/components/common/Header/styled.ts
+++ b/src/components/common/Header/styled.ts
@@ -78,10 +78,6 @@ const LogoutButton = styled.button`
   ${({ theme }): string => theme.fonts.caption01M};
 `
 
-const SellButtonDivider = styled.div`
-  width: 32px;
-`
-
 const HeaderAuthButton = styled(Button)`
   margin: 0;
   padding: 0;
@@ -142,7 +138,6 @@ export const Styled = {
   ButtonSection,
   HeaderAuthButton,
   LogoutButton,
-  SellButtonDivider,
   HeaderProfileSection,
   HeaderNickName,
   MenuSection,

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,2 +1,5 @@
 export * from './Tabs'
 export * from './CommonModal'
+export * from './Header'
+export * from './AlertModal'
+export * from './Dialog'

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -1,11 +1,34 @@
 import styled from '@emotion/styled'
+import { useMedia } from '@offer-ui/react'
+import { useRouter } from 'next/router'
 import type { PropsWithChildren } from 'react'
+import { Header } from '@components'
 
 type LayoutProps = PropsWithChildren<unknown>
 
-export const Layout = ({ children }: LayoutProps) => (
-  <Container>{children}</Container>
-)
+const NO_HEADER_PATHS: { [key: string]: string[] } = {
+  desktop: [],
+  tablet: ['/post'],
+  mobile: ['/post']
+}
+type MediaTypeKeys = keyof typeof NO_HEADER_PATHS
+
+export const Layout = ({ children }: LayoutProps) => {
+  const router = useRouter()
+  const media = useMedia()
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [key] = Object.entries(media).find(([_, value]) => value) || []
+  // TODO: UseMediaType export 해서 타입 지정 해주기
+  const currentMedia = key as MediaTypeKeys
+  const hasHeader = !NO_HEADER_PATHS[currentMedia].includes(router.pathname)
+
+  return (
+    <Container>
+      {hasHeader && <Header />}
+      {children}
+    </Container>
+  )
+}
 
 const Container = styled.div`
   margin-top: 67px;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,7 +2,6 @@ import { OfferStyleProvider, theme as offerTheme } from '@offer-ui/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { AppProps } from 'next/app'
 import type { ReactElement } from 'react'
-import { Header } from '@components/common/Header'
 import { env } from '@constants'
 import { Layout } from '@layouts'
 import { theme } from '@styles'
@@ -24,7 +23,6 @@ const App = ({ Component, pageProps }: AppProps): ReactElement | null => {
   return (
     <QueryClientProvider client={queryClient}>
       <OfferStyleProvider theme={customTheme}>
-        <Header />
         <Layout>
           <Component {...pageProps} />
         </Layout>

--- a/src/pages/post/index.tsx
+++ b/src/pages/post/index.tsx
@@ -280,16 +280,18 @@ const StyledTitleInput = styled(Input)`
 const StyledPostPage = styled.div`
   max-width: 1200px;
   margin: 0 auto;
-  padding: 42px 24px 0;
+  padding-top: 42px;
 
   ${({ theme }) => css`
     ${theme.mediaQuery.tablet} {
       margin: 0;
+      margin-top: -67px;
       padding: 0;
     }
 
     ${theme.mediaQuery.mobile} {
       margin: 0;
+      margin-top: -67px;
       padding: 0;
     }
   `};


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #181 

## ⛳ 구현 사항
* pc: header 로고만 보이도록
* tablet, mobile: header 없음
* post페이지 header에 따른 디자인 수정


## ⏳ 실행 화면
### _PC_
<img width="1440" alt="스크린샷 2023-12-13 오후 11 23 10" src="https://github.com/price-offer/offer-fe/assets/70738281/990f0f17-c1fa-4774-b58b-9c49a4f5628f">

 
### Tablet, Mobile
<img width="564" alt="스크린샷 2023-12-13 오후 11 23 16" src="https://github.com/price-offer/offer-fe/assets/70738281/7be0c77b-b9f7-4f3b-8104-f05288b181f7">



<!-- ## 💡 코드 리뷰 포인트 -->

<!-- ## 🔥 이슈와 해결 방안 -->

<!-- ## 🛠 피드백 반영 사항 -->
