### PR TITLE
fix: 외부 이미지 관련 에러 디버깅

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,7 @@
 module.exports = {
   swcMinify: true,
-  reactStrictMode: false
+  reactStrictMode: false,
+  images: {
+    domains: ['offer-be.kro.kr']
+  }
 }


### PR DESCRIPTION
## ⛳ 구현 사항
- 외부 이미지 로드 시, 발생하는 에러를 해결하였습니다.
  - next config에 외부 이미지 주소의 호스트네임을 등록
    - [관련 링크1](https://velog.io/@hhhminme/Next.js%EC%97%90%EC%84%9C-Nextimage%EC%97%90%EC%84%9C-%EC%99%B8%EB%B6%80-%EC%9D%B4%EB%AF%B8%EC%A7%80%EB%A5%BC-%EB%AA%BB%EA%B0%80%EC%A0%B8%EC%98%A4%EB%8A%94-%EB%AC%B8%EC%A0%9C%EB%8F%84%EB%A9%94%EC%9D%B8-%EC%84%A4%EC%A0%95%ED%95%98%EA%B8%B0-loader-%EC%A0%81%EC%9A%A9%ED%95%98%EA%B8%B0)
    - [관련 링크2](https://github.com/vercel/next.js/discussions/20953)

## 📚 구현 설명
<img width="1144" alt="image" src="https://github.com/price-offer/offer-fe/assets/47546413/016b5ebb-a334-402b-a18a-c208f7080324">

