### PR TITLE
feat: main, result 페이지 placeholder 추가

### DIFF
--- a/src/components/home/ProductList/index.tsx
+++ b/src/components/home/ProductList/index.tsx
@@ -39,7 +39,6 @@ const ProductList = ({
 
   return (
     <>
-      <Styled.NewProductTitle>새로운 상품</Styled.NewProductTitle>
       <Styled.ProductListWrapper>
         {postData?.map(page =>
           page?.posts?.map(post => (

--- a/src/components/home/ProductList/styled.ts
+++ b/src/components/home/ProductList/styled.ts
@@ -1,30 +1,22 @@
 import styled from '@emotion/styled'
 
-const NewProductTitle = styled.div`
-  ${({ theme }): string => theme.fonts.headline02B}
-  margin-top: 52px;
-  margin-bottom: 22px;
-  ${({ theme }): string => theme.mediaQuery.tablet} {
-    ${({ theme }): string => theme.fonts.subtitle01B}
-    margin-top: 40px;
-    margin-bottom: 20px;
-  }
-  ${({ theme }): string => theme.mediaQuery.mobile} {
-    margin-bottom: 16px;
-  }
-`
-
 const ProductListWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
   gap: 30px;
   justify-content: start;
 
+  margin-top: 20px;
+
   ${({ theme }): string => theme.mediaQuery.tablet} {
     gap: 18px 20px;
+
+    margin-top: 20px;
   }
   ${({ theme }): string => theme.mediaQuery.mobile} {
     gap: 15px 50px;
+
+    margin-top: 16px;
   }
 `
 
@@ -33,7 +25,6 @@ const LastFooter = styled.div`
 `
 
 export const Styled = {
-  NewProductTitle,
   ProductListWrapper,
   LastFooter
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,6 +19,7 @@ const Home: NextPage = () => {
       <HomeWrapper>
         <HomeBanner />
         <CategorySlider />
+        <ProductTitle>새로운 상품</ProductTitle>
         <ProductList
           fetchNextPage={fetchNextPage}
           hasNextPage={hasNextPage}
@@ -48,6 +49,15 @@ const Layout = styled.div`
 
   width: 100%;
   margin-top: 68px;
+`
+
+const ProductTitle = styled.div`
+  ${({ theme }): string => theme.fonts.headline02B}
+  margin-top: 52px;
+  ${({ theme }): string => theme.mediaQuery.tablet} {
+    ${({ theme }): string => theme.fonts.subtitle01B}
+    margin-top: 40px;
+  }
 `
 
 export default Home

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,8 @@
+import { css } from '@emotion/react'
 import styled from '@emotion/styled'
+import { Button } from '@offer-ui/react'
 import type { NextPage } from 'next'
+import { useRouter } from 'next/router'
 import { ProductList } from '../components/home/ProductList'
 import { useGetInfinitePostsQuery } from '@apis/post'
 import { CategorySlider, HomeBanner } from '@components'
@@ -13,6 +16,10 @@ const Home: NextPage = () => {
     lastId: null,
     limit: 8
   })
+  const router = useRouter()
+
+  // TODO: 포스트 전체 갯수 내려달라고 요청해놓았습니다
+  const postsCount = 0
 
   return (
     <Layout>
@@ -20,11 +27,24 @@ const Home: NextPage = () => {
         <HomeBanner />
         <CategorySlider />
         <ProductTitle>새로운 상품</ProductTitle>
-        <ProductList
-          fetchNextPage={fetchNextPage}
-          hasNextPage={hasNextPage}
-          postData={postList?.pages}
-        />
+        {postsCount > 0 ? (
+          <ProductList
+            fetchNextPage={fetchNextPage}
+            hasNextPage={hasNextPage}
+            postData={postList?.pages}
+          />
+        ) : (
+          <Placeholder>
+            <PlaceholderTitle>새로 등록된 상품이 없어요</PlaceholderTitle>
+            <Button
+              size="medium"
+              styleType="outline"
+              width="160px"
+              onClick={() => router.push('/post')}>
+              판매글 올리기
+            </Button>
+          </Placeholder>
+        )}
       </HomeWrapper>
     </Layout>
   )
@@ -58,6 +78,24 @@ const ProductTitle = styled.div`
     ${({ theme }): string => theme.fonts.subtitle01B}
     margin-top: 40px;
   }
+`
+
+const Placeholder = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+
+  width: 100%;
+  margin: 60px 0;
+`
+
+const PlaceholderTitle = styled.div`
+  ${({ theme }) => css`
+    color: ${theme.colors.grayScale70};
+
+    ${theme.fonts.body01M};
+  `}
 `
 
 export default Home

--- a/src/pages/result/index.tsx
+++ b/src/pages/result/index.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 import { useAtomValue } from 'jotai'
 import type { GetServerSideProps, NextPage } from 'next'
@@ -74,6 +75,7 @@ const ResultPage: NextPage = ({
     limit: DEFAULT_POST_PAGE_NUMBER,
     ...searchParams
   })
+
   // TODO: 포스트 전체 갯수 내려달라고 요청해놓았습니다
   const postsCount = 0
 
@@ -114,11 +116,20 @@ const ResultPage: NextPage = ({
           searchOptions={searchOptions}
           onChangeSearchOption={handleChangeSearchOptions}
         />
-        <ProductList
-          fetchNextPage={infinitePosts?.fetchNextPage}
-          hasNextPage={infinitePosts?.hasNextPage}
-          postData={infinitePosts?.data?.pages}
-        />
+        {postsCount > 0 ? (
+          <ProductList
+            fetchNextPage={infinitePosts?.fetchNextPage}
+            hasNextPage={infinitePosts?.hasNextPage}
+            postData={infinitePosts?.data?.pages}
+          />
+        ) : (
+          <Placeholder>
+            <PlaceholderTitle>검색 결과 없음</PlaceholderTitle>
+            <PlaceholderDescription>
+              찾으시는 검색 결과가 없어요
+            </PlaceholderDescription>
+          </Placeholder>
+        )}
       </ResultWrapper>
     </Layout>
   )
@@ -150,6 +161,28 @@ const CategorySliderWrapper = styled.div`
   ${({ theme }) => theme.mediaQuery.tablet} {
     display: none;
   }
+`
+
+const Placeholder = styled.div`
+  width: 100%;
+  height: 100%;
+  margin: 120px 0;
+
+  text-align: center;
+`
+
+const PlaceholderTitle = styled.p`
+  margin-bottom: 8px;
+
+  ${({ theme }) => theme.fonts.subtitle01B}
+`
+
+const PlaceholderDescription = styled.p`
+  ${({ theme }) => css`
+    color: ${theme.colors.grayScale70};
+
+    ${theme.fonts.body01M};
+  `}
 `
 
 export default ResultPage


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #239 

## ⛳ 구현 사항
* main, result 페이지 placeholder 추가

## 📚 구현 설명

## ⏳ 실행 화면
### 메인 페이지 
<img width="1061" alt="스크린샷 2024-01-23 오후 3 22 56" src="https://github.com/price-offer/offer-fe/assets/70738281/10310142-7452-44ab-a76c-8c1691e4ba38">

### 결과물 페이지
<img width="1057" alt="스크린샷 2024-01-23 오후 3 23 25" src="https://github.com/price-offer/offer-fe/assets/70738281/200bb9db-7a65-4e5c-8896-488343e5b850">




<!-- ## 💡 코드 리뷰 포인트 -->

<!-- ## 🔥 이슈와 해결 방안 -->

<!-- ## 🛠 피드백 반영 사항 -->
