### PR TITLE
fix: 구매자일 때, 선택 라디오 버튼이 뜸

### DIFF
--- a/src/components/post/PriceOfferCard/index.tsx
+++ b/src/components/post/PriceOfferCard/index.tsx
@@ -21,7 +21,7 @@ import {
   useCreateMessageRoomMutation
 } from '@apis'
 import { SORT_OPTIONS } from '@constants'
-import { useModal } from '@hooks'
+import { useAuth, useModal } from '@hooks'
 import type { SortOption, SortOptionCodes } from '@types'
 
 const PriceOfferCard = ({
@@ -39,6 +39,7 @@ const PriceOfferCard = ({
 
   const router = useRouter()
   const offerModal = useModal()
+  const { isLogin } = useAuth()
 
   const getPostOffersQuery = useGetPostOffersQuery({
     postId,
@@ -48,6 +49,10 @@ const PriceOfferCard = ({
   const createMessageRoomMutation = useCreateMessageRoomMutation()
   const updateLikeStatusMutation = useUpdateLikeStatusMutation()
   const createOfferMutation = useCreateOfferMutation()
+
+  const offerDisabled =
+    getPostOffersQuery.data?.offerCountOfCurrentMember ===
+      getPostOffersQuery.data?.maximumOfferCount || !isLogin
 
   useEffect(() => {
     setLikePost({
@@ -195,13 +200,13 @@ const PriceOfferCard = ({
         )}
         <Divider />
         <Styled.CardFooter>
-          <Styled.LikeButton role="button" onClick={handleClickLike}>
+          <Styled.LikeButton disabled={!isLogin} onClick={handleClickLike}>
             {likePost.status ? (
               <Icon color="brandPrimary" type="heartFill" />
             ) : (
               <Icon color="grayScale90" type="heart" />
             )}
-            <Text styleType="body01B">{likePost.count}</Text>
+            <Styled.LikeText>{likePost.count}</Styled.LikeText>
           </Styled.LikeButton>
           {isSeller ? (
             <Styled.MessageButton
@@ -212,10 +217,7 @@ const PriceOfferCard = ({
             </Styled.MessageButton>
           ) : (
             <Styled.MessageButton
-              disabled={
-                getPostOffersQuery.data?.offerCountOfCurrentMember ===
-                getPostOffersQuery.data?.maximumOfferCount
-              }
+              disabled={offerDisabled}
               size="large"
               onClick={() => {
                 offerModal.openModal()

--- a/src/components/post/PriceOfferCard/index.tsx
+++ b/src/components/post/PriceOfferCard/index.tsx
@@ -52,7 +52,7 @@ const PriceOfferCard = ({
 
   const offerDisabled =
     getPostOffersQuery.data?.offerCountOfCurrentMember ===
-      getPostOffersQuery.data?.maximumOfferCount || !isLogin
+    getPostOffersQuery.data?.maximumOfferCount
 
   useEffect(() => {
     setLikePost({
@@ -198,34 +198,38 @@ const PriceOfferCard = ({
             </Text>
           </Styled.BlankCard>
         )}
-        <Divider />
-        <Styled.CardFooter>
-          <Styled.LikeButton disabled={!isLogin} onClick={handleClickLike}>
-            {likePost.status ? (
-              <Icon color="brandPrimary" type="heartFill" />
-            ) : (
-              <Icon color="grayScale90" type="heart" />
-            )}
-            <Styled.LikeText>{likePost.count}</Styled.LikeText>
-          </Styled.LikeButton>
-          {isSeller ? (
-            <Styled.MessageButton
-              disabled={!selectedOffer}
-              size="large"
-              onClick={handleClickStartMessage}>
-              쪽지하기
-            </Styled.MessageButton>
-          ) : (
-            <Styled.MessageButton
-              disabled={offerDisabled}
-              size="large"
-              onClick={() => {
-                offerModal.openModal()
-              }}>{`가격 제안하기(${
-              getPostOffersQuery.data?.offerCountOfCurrentMember || 0
-            }/2)`}</Styled.MessageButton>
-          )}
-        </Styled.CardFooter>
+        {isLogin && (
+          <>
+            <Divider />
+            <Styled.CardFooter>
+              <Styled.LikeButton onClick={handleClickLike}>
+                {likePost.status ? (
+                  <Icon color="brandPrimary" type="heartFill" />
+                ) : (
+                  <Icon color="grayScale90" type="heart" />
+                )}
+                <Styled.LikeText>{likePost.count}</Styled.LikeText>
+              </Styled.LikeButton>
+              {isSeller ? (
+                <Styled.MessageButton
+                  disabled={!selectedOffer}
+                  size="large"
+                  onClick={handleClickStartMessage}>
+                  쪽지하기
+                </Styled.MessageButton>
+              ) : (
+                <Styled.MessageButton
+                  disabled={offerDisabled}
+                  size="large"
+                  onClick={() => {
+                    offerModal.openModal()
+                  }}>{`가격 제안하기(${
+                  getPostOffersQuery.data?.offerCountOfCurrentMember || 0
+                }/2)`}</Styled.MessageButton>
+              )}
+            </Styled.CardFooter>
+          </>
+        )}
       </Styled.OfferPriceCardWrapper>
       <PriceOfferModal
         isOpen={offerModal.isOpen}

--- a/src/components/post/PriceOfferCard/index.tsx
+++ b/src/components/post/PriceOfferCard/index.tsx
@@ -50,7 +50,7 @@ const PriceOfferCard = ({
   const updateLikeStatusMutation = useUpdateLikeStatusMutation()
   const createOfferMutation = useCreateOfferMutation()
 
-  const offerDisabled =
+  const isOfferDisabled =
     getPostOffersQuery.data?.offerCountOfCurrentMember ===
     getPostOffersQuery.data?.maximumOfferCount
 
@@ -228,11 +228,9 @@ const PriceOfferCard = ({
                 </Styled.MessageButton>
               ) : (
                 <Styled.MessageButton
-                  disabled={offerDisabled}
+                  disabled={isOfferDisabled}
                   size="large"
-                  onClick={() => {
-                    offerModal.openModal()
-                  }}>{`가격 제안하기(${
+                  onClick={offerModal.openModal}>{`가격 제안하기(${
                   getPostOffersQuery.data?.offerCountOfCurrentMember || 0
                 }/2)`}</Styled.MessageButton>
               )}

--- a/src/components/post/PriceOfferCard/index.tsx
+++ b/src/components/post/PriceOfferCard/index.tsx
@@ -85,6 +85,10 @@ const PriceOfferCard = ({
   }
 
   const handleChangeOffer = (e: ChangeEvent<HTMLFormElement>) => {
+    if (!isSeller) {
+      return
+    }
+
     const offerId = Number(e.target.value)
 
     setSelectedOffer(offerId)
@@ -165,12 +169,17 @@ const PriceOfferCard = ({
                   const isSelected = selectedOffer === id
 
                   return (
-                    <Styled.Offer key={id} isSelected={isSelected}>
-                      <Radio.Input
-                        checked={isSelected}
-                        formName="offer"
-                        value={String(id)}
-                      />
+                    <Styled.Offer
+                      key={id}
+                      isSelected={isSeller && isSelected}
+                      isSeller={isSeller}>
+                      {isSeller && (
+                        <Radio.Input
+                          checked={isSelected}
+                          formName="offer"
+                          value={String(id)}
+                        />
+                      )}
                       <Styled.OfferContent>
                         <UserProfile
                           date={getTimeDiffText(date)}

--- a/src/components/post/PriceOfferCard/styled.ts
+++ b/src/components/post/PriceOfferCard/styled.ts
@@ -93,12 +93,17 @@ const BlankCard = styled.div`
   height: 120px;
   padding: 20px 0;
 `
-const Offer = styled(Radio.Label)<{ isSelected: boolean }>`
+const Offer = styled(Radio.Label)<{ isSeller: boolean; isSelected: boolean }>`
   display: flex;
   align-items: center;
 
   padding: 20px;
-  border-radius: ${({ theme }): string => theme.radius.round6};
+  ${({ theme, isSeller }) =>
+    css`
+      border-radius: ${theme.radius.round6};
+
+      cursor: ${isSeller ? 'cursor' : 'default'};
+    `};
 
   ${({ theme, isSelected }) => css`
     border: solid 1px

--- a/src/components/post/PriceOfferCard/styled.ts
+++ b/src/components/post/PriceOfferCard/styled.ts
@@ -125,7 +125,7 @@ const OfferContent = styled.div`
 `
 
 const CardBody = styled.div`
-  height: 564px;
+  max-height: 564px;
   padding: 20px 16px;
 
   ${({ theme }): string => `

--- a/src/components/post/PriceOfferCard/styled.ts
+++ b/src/components/post/PriceOfferCard/styled.ts
@@ -170,7 +170,7 @@ const MessageButton = styled(Button)`
     }
   `}
 `
-const LikeButton = styled.div`
+const LikeButton = styled.button`
   display: flex;
   gap: 4px;
   align-items: center;
@@ -181,6 +181,21 @@ const LikeButton = styled.div`
   border: ${({ theme }): string => `solid 1px ${theme.colors.grayScale20}`};
 
   cursor: pointer;
+
+  &:disabled {
+    ${({ theme }) =>
+      css`
+        background-color: ${theme.colors.grayScale20};
+
+        color: ${theme.colors.white};
+
+        svg {
+          color: ${theme.colors.white};
+        }
+      `};
+
+    cursor: default;
+  }
 
   ${({ theme }): string => `
     ${theme.mediaQuery.tablet} {
@@ -193,6 +208,12 @@ const LikeButton = styled.div`
       height: 48px;
       border-radius: ${theme.radius.round100};
     }
+  `}
+`
+
+const LikeText = styled.span`
+  ${({ theme }) => css`
+    ${theme.fonts.body01B}
   `}
 `
 
@@ -209,5 +230,6 @@ export const Styled = {
   CardBody,
   CardFooter,
   MessageButton,
-  LikeButton
+  LikeButton,
+  LikeText
 }

--- a/src/components/post/PriceOfferCard/styled.ts
+++ b/src/components/post/PriceOfferCard/styled.ts
@@ -178,24 +178,14 @@ const LikeButton = styled.button`
 
   width: 96px;
   height: 64px;
-  border: ${({ theme }): string => `solid 1px ${theme.colors.grayScale20}`};
+  ${({ theme }) =>
+    css`
+      border: solid 1px ${theme.colors.grayScale20};
+
+      background-color: ${theme.colors.white};
+    `};
 
   cursor: pointer;
-
-  &:disabled {
-    ${({ theme }) =>
-      css`
-        background-color: ${theme.colors.grayScale20};
-
-        color: ${theme.colors.white};
-
-        svg {
-          color: ${theme.colors.white};
-        }
-      `};
-
-    cursor: default;
-  }
 
   ${({ theme }): string => `
     ${theme.mediaQuery.tablet} {


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #251 

## ⛳ 구현 사항
* [구매자일 때, 선택 라디오 버튼이 뜸](https://www.notion.so/shinhyojeong/5107c4fa174143e18fcfbb2dc8462024?pvs=4)
* 로그인 전에는 제안, 좋아요 버튼 뜨지 않도록 수정


## ⏳ 실행 화면
### _구매자인 경우_
<img width="510" alt="스크린샷 2024-01-30 오전 1 17 35" src="https://github.com/price-offer/offer-fe/assets/70738281/c93f5509-ae99-445d-8c44-be60e3aa88ef">

### _로그인 전_
<img width="530" alt="스크린샷 2024-01-30 오전 1 17 46" src="https://github.com/price-offer/offer-fe/assets/70738281/06a7d550-c6b8-4f8e-94ae-52acca9982ed">


<!-- ## 💡 코드 리뷰 포인트 -->

<!-- ## 🔥 이슈와 해결 방안 -->

<!-- ## 🛠 피드백 반영 사항 -->
