### PR TITLE
fix: 프로필 재수정 시, 이전 프로필 정보가 저장되어 있지 않음

### DIFF
--- a/src/components/shop/EditProfileModal/index.tsx
+++ b/src/components/shop/EditProfileModal/index.tsx
@@ -33,14 +33,12 @@ export const EditProfileModal = ({
   onClose,
   onConfirm
 }: EditProfileModalProps): ReactElement => {
-  const validateNickname = useValidateNickname()
-
   const [profileForm, setProfileForm] = useState<EditProfileForm>(profile)
   const [nickNameValidate, setNickNameValidate] = useState(
     initialNickNameValidate
   )
+  const validateNickname = useValidateNickname()
   const createUploadImage = useCreateUploadImagesMutation()
-  const canEdit = nickNameValidate.isSuccess || profileForm.image.file
 
   const handleChangeProfileImage = async (
     image: EditProfileForm['image']
@@ -60,8 +58,10 @@ export const EditProfileModal = ({
   }
 
   const { uploaderRef, openUploader, changeImage } = useImageUploader({
-    onChange: async image => handleChangeProfileImage(image)
+    onChange: handleChangeProfileImage
   })
+
+  const canEdit = nickNameValidate.isSuccess || profileForm.image.file
 
   const handleChangeNickname: ChangeEventHandler<HTMLInputElement> = e => {
     setProfileForm({ ...profileForm, nickname: e.target.value })

--- a/src/components/shop/EditProfileModal/index.tsx
+++ b/src/components/shop/EditProfileModal/index.tsx
@@ -5,12 +5,15 @@ import {
   Button,
   Text,
   Icon,
-  useImageUploader
+  useImageUploader,
+  Input
 } from '@offer-ui/react'
 import type { ChangeEventHandler, ReactElement } from 'react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Styled } from './styled'
 import type { EditProfileForm, EditProfileModalProps } from './types'
+import { useValidateNickname } from '@hooks/useValidateNickname'
+import { useCreateUploadImagesMutation } from '@apis'
 
 const NICK_NAME_MAX_LENGTH = 20
 
@@ -19,29 +22,57 @@ const initialProfileForm = {
   nickname: ''
 }
 
+const initialNickNameValidate = {
+  isSuccess: false,
+  message: ''
+}
+
 export const EditProfileModal = ({
   isOpen,
-  validate,
-  onValidateNickname,
+  profile,
   onClose,
-  onConfirm,
-  onChangeImage
+  onConfirm
 }: EditProfileModalProps): ReactElement => {
-  const [profileForm, setProfileForm] =
-    useState<EditProfileForm>(initialProfileForm)
-  const { uploaderRef, openUploader, changeImage } = useImageUploader({
-    onChange: async image => {
-      const uploadedImage = await onChangeImage(image)
-      setProfileForm({ ...profileForm, image: uploadedImage })
+  const validateNickname = useValidateNickname()
+
+  const [profileForm, setProfileForm] = useState<EditProfileForm>(profile)
+  const [nickNameValidate, setNickNameValidate] = useState(
+    initialNickNameValidate
+  )
+  const createUploadImage = useCreateUploadImagesMutation()
+  const canEdit = nickNameValidate.isSuccess || profileForm.image.file
+
+  const handleChangeProfileImage = async (
+    image: EditProfileForm['image']
+  ): Promise<void> => {
+    if (!image.file) {
+      return
     }
+
+    const imageFormData = new FormData()
+    imageFormData.append('files', image.file)
+    const { imageUrls } = await createUploadImage.mutateAsync(imageFormData)
+
+    setProfileForm(prev => ({
+      ...prev,
+      image: { id: image.id, file: image.file, url: imageUrls[0] }
+    }))
+  }
+
+  const { uploaderRef, openUploader, changeImage } = useImageUploader({
+    onChange: async image => handleChangeProfileImage(image)
   })
 
   const handleChangeNickname: ChangeEventHandler<HTMLInputElement> = e => {
     setProfileForm({ ...profileForm, nickname: e.target.value })
   }
-  const handleClickDuplicateButton = () => {
-    onValidateNickname(profileForm.nickname.trim())
+
+  const handleClickDuplicateButton = async () => {
+    const validate = await validateNickname(profileForm.nickname.trim())
+
+    setNickNameValidate(validate)
   }
+
   const handleConfirm = () => {
     onConfirm(profileForm)
   }
@@ -49,7 +80,12 @@ export const EditProfileModal = ({
   const handleClose = () => {
     onClose?.()
     setProfileForm(initialProfileForm)
+    setNickNameValidate(initialNickNameValidate)
   }
+
+  useEffect(() => {
+    setProfileForm(profile)
+  }, [profile])
 
   return (
     <Modal isOpen={isOpen} onClose={handleClose}>
@@ -83,7 +119,7 @@ export const EditProfileModal = ({
           <Text color="grayScale70" styleType="body01M" tag="p">
             닉네임
           </Text>
-          <input
+          <Input
             maxLength={NICK_NAME_MAX_LENGTH}
             placeholder="닉네임을 입력해 주세요."
             value={profileForm.nickname}
@@ -92,11 +128,11 @@ export const EditProfileModal = ({
           <Text color="grayScale50" styleType="caption01M" tag="p">
             {profileForm.nickname.length}/{NICK_NAME_MAX_LENGTH}
           </Text>
-          {!!validate.message && (
+          {!!nickNameValidate.message && (
             <Text
-              color={validate.isSuccess ? 'actSuccess' : 'actError'}
+              color={nickNameValidate.isSuccess ? 'actSuccess' : 'actError'}
               styleType="caption01M">
-              {validate.message}
+              {nickNameValidate.message}
             </Text>
           )}
           <Styled.DuplicateButton
@@ -108,10 +144,7 @@ export const EditProfileModal = ({
         </Styled.EditNickName>
       </Styled.Body>
       <div>
-        <Button
-          disabled={!validate.isSuccess}
-          size="large"
-          onClick={handleConfirm}>
+        <Button disabled={!canEdit} size="large" onClick={handleConfirm}>
           저장
         </Button>
       </div>

--- a/src/components/shop/EditProfileModal/types.ts
+++ b/src/components/shop/EditProfileModal/types.ts
@@ -8,10 +8,6 @@ export type EditProfileForm = {
 export type EditProfileValidate = { isSuccess: boolean; message: string }
 
 export type EditProfileModalProps = Pick<ModalProps, 'isOpen' | 'onClose'> & {
-  validate: EditProfileValidate
-  onValidateNickname(nickname: string): void
+  profile: EditProfileForm
   onConfirm(profile: EditProfileForm): void
-  onChangeImage(
-    image: EditProfileForm['image']
-  ): Promise<EditProfileForm['image']>
 }

--- a/src/components/shop/layout/index.tsx
+++ b/src/components/shop/layout/index.tsx
@@ -8,7 +8,7 @@ import { ProfileBox } from '../ProfileBox'
 import { Tabs } from '@components/common'
 import { pageTabs, tabList } from '@components/shop/pageTabs'
 import { useGetProfileQuery, useUpdateMyProfileMutation } from '@apis'
-import { useModal } from '@hooks'
+import { useAuth, useModal } from '@hooks'
 import type { TradeActivityCodes } from '@types'
 import { isNumber } from '@utils'
 
@@ -22,6 +22,7 @@ export const ShopPageLayout = ({
 }: ShopPageLayoutProps) => {
   const defaultTabIndex = tabList.findIndex(tab => tab === currentTab)
   const [currentPage, setCurrentPage] = useState<TradeActivityCodes>(currentTab)
+  const { refetch: userRefetch } = useAuth()
 
   const profile = useGetProfileQuery(memberId)
   const updateMyProfile = useUpdateMyProfileMutation()
@@ -43,7 +44,10 @@ export const ShopPageLayout = ({
       nickname: profileForm.nickname,
       profileImageUrl: profileForm.image.url
     })
+    // MEMO: 동일한 api를 다른 상태로 다루고 있어서 Header의 유저 정보 업데이트를 위해 두번 리패치해야하는 이슈가 있습니다.
+    // TODO: 추후에 Header와 동일한 유저 정보를 사용하도록 구조적인 변경이 필요합니다.
     await profile.refetch()
+    await userRefetch()
   }
 
   return (

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -25,6 +25,7 @@ export const useAuth = () => {
     isLogin,
     isLoading: getMyProfileQuery.isLoading,
     handleLogout,
-    user: getMyProfileQuery.data
+    user: getMyProfileQuery.data,
+    refetch: getMyProfileQuery.refetch
   }
 }


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #267 

## ⛳ 구현 사항
* 프로필 재수정 시, 이전 프로필 정보가 저장되어 있지 않음
* 프로필 수정시 Header에 반영되도록
* 프로필 이미지만 수정시에도 저장할 수 있도록

## 📚 구현 설명
* 현재 나의 프로필인 경우 Header의 user와 shop/layout의 user가 동일한 api로 패치해오는 정보임에도 불구하고 다른 상태로 다뤄지고 있어 프로필 수정시 (shop에 있는 프로필 업데이트와 header에 있는 프로필 업데이트를 위해)두번 refetch해야하는 이슈가 있습니다. 구조적인 변경이 필요해 리소스가 클 것 같아 우선은 두번 리패치 해놓은 상태입니다.

## ⏳ 실행 화면 


https://github.com/price-offer/offer-fe/assets/70738281/478c63a7-86fb-44f1-a878-9411b21f9bf9





<!-- ## 💡 코드 리뷰 포인트 -->

<!-- ## 🔥 이슈와 해결 방안 -->

<!-- ## 🛠 피드백 반영 사항 -->
