### PR TITLE
fix: 이미지 캐러셀 버튼을 누르면 이미지 전체보기가 됨

### DIFF
--- a/src/pages/post/[postId]/index.tsx
+++ b/src/pages/post/[postId]/index.tsx
@@ -81,6 +81,10 @@ const PostDetailPage = ({ postId }: Props): ReactElement => {
     return <></>
   }
 
+  const handleChangeIndicator = (idx: number) => {
+    setSelectedImageIndex(idx)
+  }
+
   return (
     <>
       <Layout>
@@ -90,7 +94,7 @@ const PostDetailPage = ({ postId }: Props): ReactElement => {
             isArrow
             name="post-carousel"
             selectedIndex={0}
-            onChangeIndicator={idx => setSelectedImageIndex(idx)}
+            onChangeIndicator={handleChangeIndicator}
             onClickImage={imageModal.openModal}
           />
           <Content>

--- a/src/pages/post/[postId]/index.tsx
+++ b/src/pages/post/[postId]/index.tsx
@@ -48,6 +48,7 @@ const PostDetailPage = ({ postId }: Props): ReactElement => {
 
   const router = useRouter()
   const [tradeStatus, setTradeStatus] = useState<TradeStatusCodes>()
+  const [selectedImageIndex, setSelectedImageIndex] = useState(0)
 
   const tradeStatusDialog = useModal()
   const deleteModal = useModal()
@@ -84,14 +85,14 @@ const PostDetailPage = ({ postId }: Props): ReactElement => {
     <>
       <Layout>
         <Main>
-          <div onClick={imageModal.openModal}>
-            <Carousel
-              images={postImages}
-              isArrow
-              name="post-carousel"
-              selectedIndex={0}
-            />
-          </div>
+          <Carousel
+            images={postImages}
+            isArrow
+            name="post-carousel"
+            selectedIndex={0}
+            onChangeIndicator={idx => setSelectedImageIndex(idx)}
+            onClickImage={imageModal.openModal}
+          />
           <Content>
             <div>
               <ProductCondition>
@@ -179,6 +180,7 @@ const PostDetailPage = ({ postId }: Props): ReactElement => {
         images={postImages}
         isOpen={imageModal.isOpen}
         name="post-detail"
+        selectedIndex={selectedImageIndex}
         onClose={imageModal.closeModal}
       />
       <CommonModal

--- a/src/pages/post/index.tsx
+++ b/src/pages/post/index.tsx
@@ -189,7 +189,7 @@ const PostPage = ({ type, editPostId }: Props): ReactElement => {
               onChange={e => handleUpdatePostForm('title', e.target.value)}
             />
             <StyledTitleLength styleType="subtitle01M">
-              {postForm.title?.length}/40
+              {postForm.title?.length || 0}/40
             </StyledTitleLength>
           </StyledTitleWrapper>
           <div>


### PR DESCRIPTION
## 🔗 이슈 번호

- closed #263 

## ⛳ 구현 사항
* [이미지 캐러셀 버튼을 누르면 이미지 전체보기가 됨](https://www.notion.so/shinhyojeong/90773e7527c04e2abbb018de81894241?pvs=4)
* 보고있던 이미지를 모달로 띄우도록

 <!-- ## ⏳ 실행 화면 -->

<!-- ## 💡 코드 리뷰 포인트 -->

<!-- ## 🔥 이슈와 해결 방안 -->

<!-- ## 🛠 피드백 반영 사항 -->
